### PR TITLE
コンテナ内のrailsが見つからないバグを修正

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -9,6 +9,8 @@ gem "puma", ">= 5.0"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 # gem "jbuilder"
 
+gem 'railties', '~> 8.0'
+
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -303,6 +303,7 @@ DEPENDENCIES
   kamal
   puma (>= 5.0)
   rails (~> 8.0.1)
+  railties (~> 8.0)
   rubocop-rails-omakase
   solid_cable
   solid_cache

--- a/compose.yml
+++ b/compose.yml
@@ -25,5 +25,5 @@ services:
       BUNDLE_WITHOUT: "development"
       PORT: "8000"
     volumes:
-      - ./api:/rails  # ローカルの api ディレクトリをコンテナの /rails にマウント
+      - ./api:/api  # ローカルの api ディレクトリをコンテナの /api にマウント
     restart: always


### PR DESCRIPTION
## 関連issue
なし

## 概要
-  apiコンテナ内に

## 変更内容
- gemが参照するパスと実際にrfailsがあるパスが異なったため、シンボリックリンクを作成
- rails環境を開発環境へ変更

## 確認項目
- [x] 'docker compose up'後に`http://0.0.0.0:8000`でrailsのロゴが見れる

## 備考
- その他、レビュワーに伝えたいことがあれば記述してください。